### PR TITLE
build: use new docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:16.10.0
+      - image: cimg/node:16.10
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/node:16.10
+      - image: cimg/node:16.20
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Use updated Docker images from CircleCI instead of the old deprecated ones