### PR TITLE
feat: Transfer Lock Functionality

### DIFF
--- a/contracts/LegitimatePhysicalNFTv3.sol
+++ b/contracts/LegitimatePhysicalNFTv3.sol
@@ -38,7 +38,7 @@ contract LegitimatePhygitalNFTv3 is ERC721Royalty, ERC721Enumerable, AccessContr
     // until it has been unlocked by tapping the LGT tag and submitting the chip's signature to the API
     // this effectively turns the NFT into a semi soul bound NFT and prevents the NFT from being traded
     // without transferring the physical item to the new owner as well
-    bool public preventTransferWhenLocked = false;
+    bool public preventTransferWhenLocked = true;
 
     constructor() ERC721("LGTPhygitalNFTv3Example", "LGTNFTv3Example") {
       // contract deployer is the admin by default

--- a/contracts/LegitimatePhysicalNFTv3.sol
+++ b/contracts/LegitimatePhysicalNFTv3.sol
@@ -33,6 +33,11 @@ contract LegitimatePhygitalNFTv3 is ERC721Royalty, ERC721Enumerable, AccessContr
     // can also be used to determine whether exclusive digital content is still active
     bool public isServiceActive = true;
 
+    // this governs the transfer lock functionality
+    // when the token is in a locked state after the transfer, the token cannot be transferred again
+    // until it has been unlocked by tapping the LGT tag and submitting the chip's signature to the API
+    // this effectively turns the NFT into a semi soul bound NFT and prevents the NFT from being traded
+    // without transferring the physical item to the new owner as well
     bool public preventTransferWhenLocked = false;
 
     constructor() ERC721("LGTPhygitalNFTv3Example", "LGTNFTv3Example") {

--- a/scripts/deployLegitimateNFTv3.ts
+++ b/scripts/deployLegitimateNFTv3.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import { getNetworkName, getDeployerAddress } from './utils'
 import {ethers} from 'hardhat'
 
-const CONTRACT_NAME = "LegitimatePhysicalNFTv3"
+const CONTRACT_NAME = "LegitimatePhygitalNFTv3"
 
 async function main() {
   console.log(`Starting deployment script...`)

--- a/scripts/verifyEtherscan.ts
+++ b/scripts/verifyEtherscan.ts
@@ -1,11 +1,11 @@
-import { getAddressBook, getDeployerAddress } from './utils'
+import { getAddressBook } from './utils'
 
 async function main() {
   const addressBook = await getAddressBook()
 
   // @ts-expect-error
   await hre.run("verify:verify", {
-    address: addressBook.Contracts.LegitimatePhysicalNFTv3,
+    address: addressBook.Contracts.LegitimatePhygitalNFTv3,
     constructorArguments: []
   })
 }


### PR DESCRIPTION
The LGT Phygital v3 protocol has an optional transfer lock mechanism that prevents people from actively trading the digital NFT without the physical counterpart.

After an NFT has been sent to the new owner, the new owner needs to unlock the NFT in order to view the exclusive content or transfer it to the next person. 

Creators can opt out of this functionality if desired.