### PR TITLE
Thecalvinchan/feat/erc 5192

### DIFF
--- a/contracts/LockedNFT/Locked721.sol
+++ b/contracts/LockedNFT/Locked721.sol
@@ -42,9 +42,9 @@ contract Locked721 is ERC721, Locked721Base {
     public
     view
     virtual
-    override(ERC721, AccessControl)
+    override(ERC721, Locked721Base)
     returns (bool)
     {
-      return ERC721.supportsInterface(interfaceId) || AccessControl.supportsInterface(interfaceId);
+      return ERC721.supportsInterface(interfaceId) || Locked721Base.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LockedNFT/Locked721Psi.sol
+++ b/contracts/LockedNFT/Locked721Psi.sol
@@ -42,9 +42,9 @@ contract Locked721Psi is ERC721Psi, Locked721Base {
     public
     view
     virtual
-    override(ERC721Psi, AccessControl)
+    override(ERC721Psi, Locked721Base)
     returns (bool)
     {
-      return ERC721Psi.supportsInterface(interfaceId) || AccessControl.supportsInterface(interfaceId);
+      return ERC721Psi.supportsInterface(interfaceId) || Locked721Base.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LockedNFT/base/ILocked721Base.sol
+++ b/contracts/LockedNFT/base/ILocked721Base.sol
@@ -25,6 +25,10 @@ interface ILocked721Base is IERC5192 {
     // TOKENLOCK FUNCTIONS
     function setTokenLock(uint256 tokenId, bool locked) external;
 
+    // @notice DEPRECATED: This is a helper function to support existing functionality in dApps prior to implementing ERC-5192
+    // @dev For external calls, use locked(uint256 tokenId) instead
+    function getTokenLock(uint256 tokenId) external view returns (bool);
+
     // This is used for end users to claim NFTs minted to our delegate wallet and makes the claim activation gasless for end users
     // the delegate wallet performing the claim functionality needs to own the NFT
     // we check the ownership information on our API service used by Tap

--- a/contracts/LockedNFT/base/ILocked721Base.sol
+++ b/contracts/LockedNFT/base/ILocked721Base.sol
@@ -1,12 +1,29 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.2;
 
-interface ILocked721Base {
+/// @notice EIP-5192 Minimal Souldbound NFTs (https://eips.ethereum.org/EIPS/eip-5192)
+/// @dev SBT Locked Token Interface
+interface IERC5192 {
+  /// @notice Emitted when the locking status is changed to locked.
+  /// @dev If a token is minted and the status is locked, this event should be emitted.
+  /// @param tokenId The identifier for a token.
+  event Locked(uint256 tokenId);
+
+  /// @notice Emitted when the locking status is changed to unlocked.
+  /// @dev If a token is minted and the status is unlocked, this event should be emitted.
+  /// @param tokenId The identifier for a token.
+  event Unlocked(uint256 tokenId);
+
+  /// @notice Returns the locking status of an Soulbound Token
+  /// @dev SBTs assigned to zero address are considered invalid, and queries
+  /// about them do throw.
+  /// @param tokenId The identifier for an SBT.
+  function locked(uint256 tokenId) external view returns (bool);
+}
+
+interface ILocked721Base is IERC5192 {
     // TOKENLOCK FUNCTIONS
     function setTokenLock(uint256 tokenId, bool locked) external;
-
-    // READ TOKENLOCK STATE FUNCTIONS
-    function getTokenLock(uint256 tokenId) external view returns (bool); 
 
     // This is used for end users to claim NFTs minted to our delegate wallet and makes the claim activation gasless for end users
     // the delegate wallet performing the claim functionality needs to own the NFT

--- a/contracts/LockedNFT/base/Locked721Base.sol
+++ b/contracts/LockedNFT/base/Locked721Base.sol
@@ -34,20 +34,25 @@ abstract contract Locked721Base is ILocked721Base, Locked721AccessControl {
     }
 
     // TOKENLOCK FUNCTIONS
-    function _setTokenLock(uint256 tokenId, bool locked) internal {
-      tokenLock[tokenId] = locked;
+    function _setTokenLock(uint256 _tokenId, bool _locked) internal {
+      tokenLock[_tokenId] = _locked;
+      if (_locked) {
+        emit Locked(_tokenId);
+      } else {
+        emit Unlocked(_tokenId);
+      }
     }
 
-    function setTokenLock(uint256 tokenId, bool locked) override external onlyApiDelegate {
-      _setTokenLock(tokenId, locked);
+    function setTokenLock(uint256 _tokenId, bool _locked) override external onlyApiDelegate {
+      _setTokenLock(_tokenId, _locked);
     }
 
     // READ TOKENLOCK STATE FUNCTIONS
-    function _getTokenLock(uint256 tokenId) internal virtual view returns (bool) {
-      return tokenLock[tokenId];
+    function _getTokenLock(uint256 _tokenId) internal virtual view returns (bool) {
+      return tokenLock[_tokenId];
     }
 
-    function getTokenLock(uint256 tokenId) override external view returns (bool) {
+    function locked(uint256 tokenId) override external view returns (bool) {
       return _getTokenLock(tokenId);
     }
 
@@ -94,4 +99,8 @@ abstract contract Locked721Base is ILocked721Base, Locked721AccessControl {
     // the delegate wallet performing the claim functionality needs to own the NFT
     // we check the ownership information on our API service used by Tap
     function claim(address to, uint256 tokenId) override virtual external onlyApiDelegate {}
+
+    function supportsInterface(bytes4 interfaceId) override virtual public view returns(bool) {
+      return super.supportsInterface(interfaceId) || interfaceId == type(IERC5192).interfaceId;
+    }
 }

--- a/contracts/LockedNFT/base/Locked721Base.sol
+++ b/contracts/LockedNFT/base/Locked721Base.sol
@@ -52,6 +52,12 @@ abstract contract Locked721Base is ILocked721Base, Locked721AccessControl {
       return tokenLock[_tokenId];
     }
 
+    // @notice DEPRECATED: This is a helper function to support existing functionality in dApps prior to implementing ERC-5192
+    // @dev For external calls, use locked(uint256 tokenId) instead
+    function getTokenLock(uint256 tokenId) override external view returns (bool) {
+      return _getTokenLock(tokenId);
+    }
+
     function locked(uint256 tokenId) override external view returns (bool) {
       return _getTokenLock(tokenId);
     }

--- a/test/LegitimatePhygitalNFTv3.ts
+++ b/test/LegitimatePhygitalNFTv3.ts
@@ -175,29 +175,41 @@ describe('LegitimatePhygitalNFTv3', () => {
         const totalSupply = await lgtNFT.totalSupply();
         expect(totalSupply).to.eq(initialSupply.add(numberToMint))
       })
-      it('emits the right number of events with the right args', async () => {
+      it('emits the right number of "Transfer" events with the right args', async () => {
         const tx = await lgtNFT['mint(address,uint256,uint256)'](addr1.address, startTokenId, numberToMint);
         const txReceipt = await tx.wait()
-        expect(txReceipt.events.length).to.eq(numberToMint)
+        const transferEvents = txReceipt?.events?.filter((ev: Event) => ev.event === 'Transfer')
+        expect(transferEvents.length).to.eq(numberToMint)
 
-        txReceipt?.events?.forEach(async (ev:Event, i: number) => {
+        transferEvents.forEach(async (ev:Event, i: number) => {
           const {event, args} = ev
           expect(event).to.eq('Transfer')
           expect(args?.tokenId).to.eq(i, 'id is correct')
           expect(args?.from).to.eq(ORIGIN_ADDRESS, 'from is correct')
           expect(args?.to).to.eq(addr1.address, 'to is correct')
-          const tokenLock = await lgtNFT.getTokenLock(args?.tokenId)
+        })
+      })
+      it('emits the right number of "Locked" events with the right args', async () => {
+        const tx = await lgtNFT['mint(address,uint256,uint256)'](addr1.address, startTokenId, numberToMint);
+        const txReceipt = await tx.wait()
+        const transferEvents = txReceipt?.events?.filter((ev: Event) => ev.event === 'Locked')
+        expect(transferEvents.length).to.eq(numberToMint)
+
+        transferEvents.forEach(async (ev:Event, i: number) => {
+          const {event, args} = ev
+          expect(event).to.eq('Locked')
+          expect(args?.tokenId).to.eq(i, 'id is correct')
+          const tokenLock = await lgtNFT.locked(args?.tokenId)
           expect(tokenLock).to.eq(true)
-          const owner = await lgtNFT.ownerOf(args?.tokenId)
-          expect(owner, addr1.address)
         })
       })
       it('the owner of the tokenIDs is correct', async () => {
         const tx = await lgtNFT['mint(address,uint256,uint256)'](addr1.address, startTokenId, numberToMint);
         const txReceipt = await tx.wait()
-        expect(txReceipt.events.length).to.eq(numberToMint)
+        const transferEvents = txReceipt?.events?.filter((ev: Event) => ev.event === 'Transfer')
+        expect(transferEvents.length).to.eq(numberToMint)
 
-        txReceipt?.events?.forEach(async (ev: Event) => {
+        transferEvents.forEach(async (ev:Event) => {
           const {event, args} = ev
           expect(event).to.eq('Transfer')
           const tokenId = args?.tokenId
@@ -220,7 +232,7 @@ describe('LegitimatePhygitalNFTv3', () => {
         txReceipt?.events?.forEach(async (ev: Event) => {
           const {args} = ev
           const tokenId = args?.tokenId
-          const tokenLocked = await lgtNFT.getTokenLock(tokenId)
+          const tokenLocked = await lgtNFT.locked(tokenId)
           expect(tokenLocked).to.eq(false)
         })
       })
@@ -230,7 +242,7 @@ describe('LegitimatePhygitalNFTv3', () => {
         txReceipt?.events?.forEach(async (ev: Event) => {
           const {args} = ev
           const tokenId = args?.tokenId
-          const tokenLocked = await lgtNFT.getTokenLock(tokenId)
+          const tokenLocked = await lgtNFT.locked(tokenId)
           expect(tokenLocked).to.eq(false)
         })
       })
@@ -241,14 +253,14 @@ describe('LegitimatePhygitalNFTv3', () => {
     describe('if shouldPreventTransferWhenLocked is true', async () => {
       it('should revert if token is locked', async () => {
         const tokenId = await mintToken(addr1.address)
-        const tokenLock = await lgtNFT.getTokenLock(tokenId)
+        const tokenLock = await lgtNFT.locked(tokenId)
         expect(tokenLock).to.eq(true)
 
         await expect(lgtNFT.connect(addr1).transferFrom(addr1.address, addr2.address, tokenId)).to.be.revertedWith(TOKEN_NOT_UNLOCKED);
       })
       it('no roles should be able to transfer tokens if transfer lock is set', async () => {
         const tokenId = await mintToken(addr1.address)
-        const tokenLock = await lgtNFT.getTokenLock(tokenId)
+        const tokenLock = await lgtNFT.locked(tokenId)
         expect(tokenLock).to.eq(true)
 
         // no roles should be able to transfer locked NFT when transfer lock is set
@@ -271,7 +283,7 @@ describe('LegitimatePhygitalNFTv3', () => {
         expect(event.to).to.eq(addr2.address, 'to is correct')
         const owner = await lgtNFT.ownerOf(tokenId);
         expect(owner, addr2.address);
-        expect(await lgtNFT.getTokenLock(tokenId)).to.eq(true);
+        expect(await lgtNFT.locked(tokenId)).to.eq(true);
       });
     })
 
@@ -283,7 +295,7 @@ describe('LegitimatePhygitalNFTv3', () => {
 
         const tx = await lgtNFT.transferFrom(deployerAddress, addr1.address, tokenId);
         await tx.wait()
-        expect(await lgtNFT.getTokenLock(tokenId)).to.eq(true);
+        expect(await lgtNFT.locked(tokenId)).to.eq(true);
       });
     })
   });
@@ -315,17 +327,17 @@ describe('LegitimatePhygitalNFTv3', () => {
       })
       it('allows API_DELEGATE_USER to set token lock', async () => {
         const tokenId = mintToken()
-        const tokenLock = await lgtNFT.getTokenLock(tokenId)
+        const tokenLock = await lgtNFT.locked(tokenId)
         expect(tokenLock).to.eq(true)
         await lgtNFT.connect(addr1).setTokenLock(tokenId, false)
-        expect(await lgtNFT.getTokenLock(tokenId)).to.eq(false)
+        expect(await lgtNFT.locked(tokenId)).to.eq(false)
       })
       it('does not allow non API_DELEGATE_USER to set token lock', async () => {
         const tokenId = mintToken()
-        const tokenLock = await lgtNFT.getTokenLock(tokenId)
+        const tokenLock = await lgtNFT.locked(tokenId)
         expect(tokenLock).to.eq(true)
         await expect(lgtNFT.connect(addr2).setTokenLock(tokenId, false)).to.be.revertedWith(OWNABLE_CALLER_IS_NOT_API_DELEGATE)
-        expect(await lgtNFT.getTokenLock(tokenId)).to.eq(true)
+        expect(await lgtNFT.locked(tokenId)).to.eq(true)
       })
       it('setting a token to unlocked changes the metadata url', async () => {
         const tokenId = await mintToken()
@@ -333,23 +345,40 @@ describe('LegitimatePhygitalNFTv3', () => {
         const tokenUri = await lgtNFT.tokenURI(tokenId)
         expect(tokenUri.toLowerCase()).to.eq(`${await lgtNFT.baseURI()}/${tokenId}`)
       })
-      it('if a token is unlocked, getTokenLock returns false', async () => {
+      it('setting a token to unlocked emits an "Unlocked" event with the right arg', async () => {
+        const tokenId = await mintToken()
+        const tx = await lgtNFT.setTokenLock(tokenId, false)
+        const txReceipt = await tx.wait()
+        expect (txReceipt?.events?.length).to.eq(1)
+        const [ev] = txReceipt?.events
+        expect(ev.event).to.eq("Unlocked")
+        expect(ev.args?.tokenId).to.eq(tokenId)
+      })
+      it('if a token is unlocked, locked returns false', async () => {
         const tokenId = mintToken()
         await lgtNFT.setTokenLock(tokenId, false)
-        const tokenLock = await lgtNFT.getTokenLock(tokenId)
+        const tokenLock = await lgtNFT.locked(tokenId)
         expect(tokenLock).to.eq(false)
+      })
+    })
+    describe('getTokenLock and locked', async() => {
+      it('return the same result', async () => {
+        const tokenId = mintToken(addr1.address)
+        expect(await lgtNFT.locked(tokenId)).to.eq(await lgtNFT.getTokenLock(tokenId))
+        await lgtNFT.setTokenLock(tokenId, false)
+        expect(await lgtNFT.locked(tokenId)).to.eq(await lgtNFT.getTokenLock(tokenId))
       })
     })
     describe('_afterTokenTransfer', async () => {
       it('automatically locks a token after a transfer', async () => {
         const tokenId = mintToken(addr1.address)
         await lgtNFT.setTokenLock(tokenId, false)
-        const tokenLock = await lgtNFT.getTokenLock(tokenId)
+        const tokenLock = await lgtNFT.locked(tokenId)
         expect(tokenLock).to.eq(false)
 
         await lgtNFT.connect(addr1).transferFrom(addr1.address, addr2.address, tokenId);
 
-        expect(await lgtNFT.getTokenLock(tokenId)).to.eq(true)
+        expect(await lgtNFT.locked(tokenId)).to.eq(true)
       })
     })
   })
@@ -361,10 +390,10 @@ describe('LegitimatePhygitalNFTv3', () => {
       })
       it('turns off token lock when status is off', async () => {
         await lgtNFT.setTokenLock(tokenId1, true)
-        let tokenLock = await lgtNFT.getTokenLock(tokenId1)
+        let tokenLock = await lgtNFT.locked(tokenId1)
         expect(tokenLock).to.eq(true)
         await lgtNFT.setIsServiceActive(false)
-        tokenLock = await lgtNFT.getTokenLock(tokenId1)
+        tokenLock = await lgtNFT.locked(tokenId1)
         expect(tokenLock).to.eq(false)
         let serviceStatus = await lgtNFT.getIsServiceActive()
         expect(serviceStatus).to.eq(false)
@@ -463,7 +492,7 @@ describe('LegitimatePhygitalNFTv3', () => {
 
         const owner = await lgtNFT.ownerOf(tokenId1)
         expect(owner).to.eq(addr2.address)
-        const tokenLock = await lgtNFT.getTokenLock(tokenId1)
+        const tokenLock = await lgtNFT.locked(tokenId1)
         expect(tokenLock).to.eq(false)
       })
       it('non API_DELEGATE cannot perform claim function and send NFT to Tap end consumer', async () => {


### PR DESCRIPTION
LockedBase now inherits from ERC5192, the minimal soulbound token standard.

This allows us to emit `Locked` and `Unlocked` events