### PR TITLE
feat: use constructor params from deployment for token name and symbol

### DIFF
--- a/contracts/examples/LegitimatePhygitalNFTv3PsiMetadata.sol
+++ b/contracts/examples/LegitimatePhygitalNFTv3PsiMetadata.sol
@@ -8,7 +8,7 @@ import "./LegitimateNFTMetadata.sol";
 contract LegitimatePhygitalNFTv3PsiMetadata is LegitimateNFTMetadata, LGTServiced721Psi {
     using Strings for uint256;
 
-    constructor() LGTServiced721Psi("LGTPhygitalNFTv3Example", "LGTNFTv3Example") {}
+    constructor(string memory name_, string memory symbol_) LGTServiced721Psi(name_, symbol_) {}
 
     // This generates the metadata on-chain for each NFT so metadata files do not need to be hosted
     // and unlimited number of NFTs can be minted


### PR DESCRIPTION
this should eliminate the need to verify each individual contract because the contract bytecode itself is the same